### PR TITLE
Populate user info from LDAP

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,8 @@
 .gitignore
 Dockerfile
 env
+venv
 *.db
 data
 panopticum_django/settings_local.py
+panopticum/migrations

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,5 @@ COPY ./requirements.txt .
 RUN apk add openldap jpeg zlib libpq
 RUN pip install /whl/*.whl && pip install -r requirements.txt
 COPY . .
+RUN python manage.py makemigrations
 CMD gunicorn panopticum_django.wsgi:application --bind 0.0.0.0:8000 -k gevent

--- a/helm/panopticum/values.yml
+++ b/helm/panopticum/values.yml
@@ -1,0 +1,8 @@
+database:
+  driver: sqlite
+  image:
+  imageTag: latest
+  resources:
+    requests:
+      memory: 128Mi
+      cpu: 100m

--- a/helm/panopticum/values.yml
+++ b/helm/panopticum/values.yml
@@ -1,8 +1,0 @@
-database:
-  driver: sqlite
-  image:
-  imageTag: latest
-  resources:
-    requests:
-      memory: 128Mi
-      cpu: 100m

--- a/panopticum/admin.py
+++ b/panopticum/admin.py
@@ -26,8 +26,16 @@ formfields_small = {models.ForeignKey: {'widget': Select(attrs={'width': '200px'
 
 
 class UserAdmin(django.contrib.auth.admin.UserAdmin):
-    readonly_fields = ['image']
-    fieldsets = django.contrib.auth.admin.UserAdmin.fieldsets + ((_('misc'), {'fields': ('image', )}), )
+
+    fieldsets = (
+        (None, {'fields': ('username', 'password')}),
+        (_('Personal info'), {'fields': ('first_name', 'last_name', 'email',
+                                         'office_phone', 'mobile_phone', 'image')}),
+        (_('Organization'), {'fields': ('organization', 'department', 'role', 'title', 'manager')}),
+        (_('Permissions'), {'fields': ('is_active', 'is_staff', 'is_superuser',
+                                       'groups', 'user_permissions')}),
+        (_('Important dates'), {'fields': ('last_login', 'date_joined')}),
+    )
 
     def image(self, obj):
         return mark_safe('<img src="{url}" width="{width}" height={height} />'.format(

--- a/panopticum/admin.py
+++ b/panopticum/admin.py
@@ -26,6 +26,8 @@ formfields_small = {models.ForeignKey: {'widget': Select(attrs={'width': '200px'
 
 
 class UserAdmin(django.contrib.auth.admin.UserAdmin):
+    readonly_fields = ['image', ]
+    list_display = ('username', 'first_name', 'last_name', 'is_staff', 'title')
 
     fieldsets = (
         (None, {'fields': ('username', 'password')}),

--- a/panopticum/ldap.py
+++ b/panopticum/ldap.py
@@ -1,0 +1,21 @@
+from django_auth_ldap.backend import LDAPBackend, _LDAPUser, populate_user
+
+
+class PanopticumLDAPBackend(LDAPBackend):
+    default_settings = {
+        "FOREIGNKEY_USER_ATTR_MAP": {},
+        "USER_SEARCH_FIELD": "sAMAccountName"
+    }
+
+    def create_user(self, ldap_attrs):
+        #search = django_auth_ldap.config.LDAPSearch(dn, ldap.SCOPE_BASE)
+        #related_ldap_attrs = search.execute(ldap_user._get_connection())[0][1]
+        username = ldap_attrs.data.get(
+            self.settings.USER_SEARCH_FIELD.lower())[0]
+        ldap_user = _LDAPUser(self, username)
+        ldap_user._user_attrs = ldap_attrs
+        ldap_user._get_or_create_user()
+
+        field_model_instance, built = self.get_or_build_user(username,
+                                                             ldap_user)
+        return field_model_instance

--- a/panopticum/models.py
+++ b/panopticum/models.py
@@ -8,7 +8,22 @@ from django.utils.safestring import mark_safe
 
 
 class User(AbstractUser):
+    dn = models.CharField(max_length=255, null=True)
+    title = models.CharField(max_length=64, blank=True, null=True)
     photo = models.ImageField(upload_to='avatars')
+    organization = models.ForeignKey('OrganizationModel', on_delete=models.PROTECT, blank=True,
+                                     null=True)
+    department = models.ForeignKey('OrgDepartmentModel', on_delete=models.PROTECT, blank=True,
+                                   null=True)
+    role = models.ForeignKey('PersonRoleModel', on_delete=models.PROTECT, blank=True, null=True)
+    office_phone = models.CharField(max_length=64, blank=True, null=True)
+    mobile_phone = models.CharField(max_length=64, blank=True, null=True)
+    active_directory_guid = models.CharField(max_length=64, blank=True, null=True)
+    employee_number = models.CharField(max_length=64, blank=True, null=True)
+    info = models.TextField(blank=True, null=True)
+    hidden = models.BooleanField(help_text="Hide the person from the potential assignee lists",
+                                 db_index=True, default=False)
+    manager = models.ForeignKey("self", on_delete=models.PROTECT, blank=True, null=True)
 
     @property
     def photo_url(self):

--- a/panopticum/signals.py
+++ b/panopticum/signals.py
@@ -4,6 +4,8 @@ from django.dispatch import receiver
 from rest_framework.authtoken.models import Token
 from django.core.files.base import ContentFile
 import django_auth_ldap.backend
+from panopticum_django import settings
+from panopticum import models
 
 
 @receiver(post_save, sender=settings.AUTH_USER_MODEL)
@@ -16,6 +18,27 @@ def create_auth_token(sender, instance=None, created=False, **kwargs):
 @receiver(django_auth_ldap.backend.populate_user, sender=django_auth_ldap.backend.LDAPBackend)
 def add_photo(sender, instance=None, created=False, user=None, ldap_user=None, **kwargs):
     """ Download and assign user photo at user population from LDAP """
-    if ldap_user.attrs.data['thumbnailphoto'] and not user.photo:
+    ldap_field_name = settings.LDAP_USER_ATTR_MAP.get("photo")
+
+    if ldap_field_name and ldap_user.attrs.data[ldap_field_name] and not user.photo:
         user.photo.save(name=f'{user.username}.jpg',
-                        content=ContentFile(ldap_user.attrs.data['thumbnailphoto'][0]))
+                        content=ContentFile(ldap_user.attrs.data[ldap_field_name][0]))
+
+@receiver(django_auth_ldap.backend.populate_user, sender=django_auth_ldap.backend.LDAPBackend)
+def update_user_foreign_keys(sender, instance=None, created=False, user=None, ldap_user=None, **kwargs):
+    for model_field_name, val in settings.LDAP_USER_ATTR_MAP.items():
+        search_field = "name"
+        if isinstance(val, dict):
+            ldap_field_name = val['ldapFieldName']
+            search_field = val.get("searchField", search_field)
+        else:
+            ldap_field_name = val
+
+        if ldap_user.attrs.data[ldap_field_name]:
+            field_model = getattr(models.User, model_field_name).field.related_model
+            if not field_model:
+                continue
+            field_model_instance = field_model.objects.get_or_create(**{
+                search_field:ldap_user.attrs.data[ldap_field_name][0]
+            })[0]
+            setattr(user, model_field_name, field_model_instance)

--- a/panopticum_django/settings.py
+++ b/panopticum_django/settings.py
@@ -190,10 +190,6 @@ MEDIA_URL = '/media/'
 
 AUTH_USER_MODEL = 'panopticum.User'
 
-# Object relation map for adding foreign key objects like AUTH_LDAP_USER_ATTR_MAP.
-# key is foreignKey field at django model
-# value is LDAP field
-LDAP_USER_ATTR_MAP = {}
 
 curr_dir = os.path.abspath(os.path.dirname(__file__))
 if os.path.exists(os.path.join(curr_dir, "settings_local.py")):

--- a/panopticum_django/settings.py
+++ b/panopticum_django/settings.py
@@ -190,6 +190,11 @@ MEDIA_URL = '/media/'
 
 AUTH_USER_MODEL = 'panopticum.User'
 
+# Object relation map for adding foreign key objects like AUTH_LDAP_USER_ATTR_MAP.
+# key is foreignKey field at django model
+# value is LDAP field
+LDAP_USER_ATTR_MAP = {}
+
 curr_dir = os.path.abspath(os.path.dirname(__file__))
 if os.path.exists(os.path.join(curr_dir, "settings_local.py")):
     sys.path.append(curr_dir)


### PR DESCRIPTION
populate more user fields: departament, organization, manager and more from legacy PersonModel
automatically populate dependent users at login. For example: Database is empty. I did login. My manager is Konstantin. But Konstantin doesn't exist at database. We will create account for Konstantin too.
