### PR TITLE
Permissions for component owner and signee

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,12 @@ python3.6 ./manage.py migrate
 python3.6 ./manage.py createsuperuser
 ```
 
+### Load initial fixtures
+
+```
+DJANGO_SETTINGS_MODULE=panopticum_django.settings PYTHONPATH=. django-admin loaddata init.json
+```
+
 ### Authenticate via Active Directory
 In order to use AD `settings_local.py` should contain the following:
 ```python

--- a/panopticum/admin.py
+++ b/panopticum/admin.py
@@ -1,3 +1,5 @@
+import typing
+
 import django.forms
 from django.contrib import admin
 from django.forms.widgets import SelectMultiple, NumberInput, TextInput, Textarea, Select
@@ -13,6 +15,8 @@ from panopticum.models import *
 SIGNEE_STATUS_TYPE = 2 # Requirement status type with name = "approver person". Check init.json
 OWNER_STATUS_TYPE = 1
 UNKNOWN_REQUIREMENT_STATUS = 1 # it's unknown status. Check init.json fixture
+OWNER_STATUS_PERMISSION = 'panopticum.change_owner_status'
+SIGNEE_STATUS_PERMISSION = 'panopticum.change_signee_status'
 
 formfields_large = {models.ForeignKey: {'widget': Select(attrs={'width': '300px', 'style': 'width:300px'})},
                     models.ManyToManyField: {'widget': SelectMultiple(attrs={'size': '7', 'width': '300px', 'style': 'width:300px'})},
@@ -85,28 +89,37 @@ class RequirementForm(django.forms.ModelForm):
     Pay attention: we does not have model for Requirement row. We do not need it until we can calculate it
     from requirement statues by django admin form and frontend """
     owner_status = panopticum.fields.RequirementStatusChoiceField(queryset=RequirementStatus.objects.all(),
-                                                           label='Readiness')
+                                                                  label='Readiness')
     owner_notes = django.forms.CharField(label='notes',
                                          widget=django.forms.Textarea({'rows': '2'}),
-                                         max_length=16* pow(2, 10),
+                                         max_length=16 * pow(2, 10),
                                          required=False,
                                          )
     approve_status = panopticum.fields.RequirementStatusChoiceField(
-        queryset=RequirementStatus.objects.filter(allow_for=2),  # signee status
+        queryset=RequirementStatus.objects.filter(allow_for=SIGNEE_STATUS_TYPE),
         label='Sign off'
     )
     approve_notes = django.forms.CharField(label='Sign off notes',
                                            widget=django.forms.Textarea({'rows': '2'}),
-                                           max_length=16* pow(2, 10),
+                                           max_length=16 * pow(2, 10),
                                            required=False)
     user = AnonymousUser()
+
+    class Meta:
+        fields = '__all__'
+        model = RequirementStatusEntry
+        labels = {
+            'owner_status': 'Readiness',
+            'owner_notes': 'Notes',
+            'approve_status': 'Sign off',
+            'approve_notes': 'Sign off notes'
+        }
+
     def __init__(self, *args, **kwargs):
 
-        unknown_status = RequirementStatus.objects.get(pk=UNKNOWN_REQUIREMENT_STATUS)
-
         # define initial fields values
-        self.base_fields['owner_status'].initial = unknown_status.pk
-        self.base_fields['approve_status'].initial = unknown_status.pk
+        self.base_fields['owner_status'].initial = UNKNOWN_REQUIREMENT_STATUS
+        self.base_fields['approve_status'].initial = UNKNOWN_REQUIREMENT_STATUS
 
         if kwargs.get('instance'):
             # read and set field values from status models
@@ -115,29 +128,33 @@ class RequirementForm(django.forms.ModelForm):
                 'owner_notes': kwargs['instance'].notes
             }
             try:
-                signee_status_obj = RequirementStatusEntry.objects.get(
-                    requirement=kwargs['instance'].requirement,
-                    type=SIGNEE_STATUS_TYPE,
-                    component_version=kwargs['instance'].component_version
-                )
+                signee_status_obj = self.get_signee_status(kwargs['instance'])
                 initial['approve_status'] = signee_status_obj.status.pk
                 initial['approve_notes'] = signee_status_obj.notes
             except django.core.exceptions.ObjectDoesNotExist:
                 # set default values for signee
-                initial['approve_status'] = 1  # unknown
+                initial['approve_status'] = UNKNOWN_REQUIREMENT_STATUS
 
             kwargs.update(initial=initial)
 
         super().__init__(*args, **kwargs)
 
-        if 'instance' in kwargs: # disable defined requirement. We disallow to change requirement title after save
+        if 'instance' in kwargs:  # disable defined requirement. We disallow to change requirement title after save
             self.fields['requirement'].disabled = True
-        if not self.user.has_perm('panopticum.change_owner_status'):
+        if not self.user.has_perm(OWNER_STATUS_PERMISSION):
             self.fields['owner_status'].disabled = True
             self.fields['owner_notes'].disabled = True
-        if not self.user.has_perm('panopticum.change_signee_status'):
+        if not self.user.has_perm(SIGNEE_STATUS_PERMISSION):
             self.fields['approve_status'].disabled = True
             self.fields['approve_notes'].disabled = True
+
+    @staticmethod
+    def get_signee_status(obj):
+        return RequirementStatusEntry.objects.get(
+            requirement=obj.requirement,
+            type=SIGNEE_STATUS_TYPE,
+            component_version=obj.component_version
+        )
 
     def is_valid(self):
         # skip validation for 3 empty requirement rows that added bellow
@@ -177,7 +194,19 @@ class RequirementForm(django.forms.ModelForm):
 class RequirementStatusEntryAdmin(admin.TabularInline):
     model = RequirementStatusEntry
     form = RequirementForm
-    fields = ('requirement', 'owner_status', 'owner_notes','approve_status',  'approve_notes')
+    fields = ('requirement', 'owner_status', 'owner_notes', 'approve_status', 'approve_notes')
+
+    def owner_status(self, obj):
+        return obj.status.name
+
+    def owner_notes(self, obj):
+        return obj.notes
+
+    def approve_status(self, obj):
+        return self.form.get_signee_status(obj).status.name
+
+    def approve_notes(self, obj):
+        return self.form.get_signee_status(obj).notes
 
     def get_formset(self, request, obj=None, **kwargs):
         self.form.user = request.user
@@ -186,18 +215,17 @@ class RequirementStatusEntryAdmin(admin.TabularInline):
     def get_queryset(self, request):
         qs =super().get_queryset(request)
         # show requirements available for requirement set owners only
-        if not request.user.has_perm('panopticum.change_owner_status') and \
-                request.user.has_perm('panopticum.change_signee_status'):
+        if not request.user.has_perm(OWNER_STATUS_PERMISSION) and \
+                request.user.has_perm(SIGNEE_STATUS_PERMISSION):
             return qs.filter(type=SIGNEE_STATUS_TYPE,
                              requirement__sets__owner_groups__in=request.user.groups.all())
         return qs.filter(type=OWNER_STATUS_TYPE)
 
-
     def formfield_for_foreignkey(self, db_field, request, **kwargs):
         requirement_qs = Requirement.objects.all()
         # choice list must contain only requirements available for requirement set owners
-        if not request.user.has_perm('panopticum.change_owner_status') and \
-                request.user.has_perm('panopticum.change_signee_status'):
+        if not request.user.has_perm(OWNER_STATUS_PERMISSION) and \
+                request.user.has_perm(SIGNEE_STATUS_PERMISSION):
             requirement_qs = requirement_qs.filter(sets__owner_groups__in=request.user.groups.all())
 
         field_map = {
@@ -211,14 +239,26 @@ class RequirementStatusEntryAdmin(admin.TabularInline):
         else:
             return super().formfield_for_foreignkey(db_field, request, **kwargs)
 
+    def has_change_permission(self, request, obj=None):
+        """ Allow change requirement if user have permissions """
+        return request.user.has_perm(SIGNEE_STATUS_PERMISSION) or \
+               (request.user.has_perm(OWNER_STATUS_PERMISSION) and
+                obj and request.user == obj.owner_maintainer)
+
+    def has_add_permission(self, request, obj=None):
+        return self.has_change_permission(request, obj)
+
+
 class RequirementAdmin(admin.ModelAdmin):
     list_display = ['title']
     model = Requirement
+
 
 class RequirementSetAdmin(admin.ModelAdmin):
     filter_horizontal = ['requirements', 'owner_groups']
     list_display = ['name']
     model = RequirementSet
+
 
 class ComponentVersionAdmin(admin.ModelAdmin):
     formfield_overrides = formfields_large
@@ -252,6 +292,11 @@ class ComponentVersionAdmin(admin.ModelAdmin):
                                      ('qa_upgrade_tests_status', 'qa_upgrade_tests_notes'))}),
     ]
 
+    def has_change_permission(self, request, obj: typing.Optional[ComponentVersionModel] =None):
+        return request.user.is_superuser or \
+               (obj and request.user == obj.owner_maintainer)
+
+
     def formfield_for_manytomany(self, db_field, request, **kwargs):
         # standard django method
         if db_field.name in ("owner_product_manager", "owner_program_manager", "owner_expert",
@@ -260,10 +305,38 @@ class ComponentVersionAdmin(admin.ModelAdmin):
         return super().formfield_for_foreignkey(db_field, request, **kwargs)
 
     def formfield_for_foreignkey(self, db_field, request, **kwargs):
-        # standard django method
         if db_field.name in ("owner_maintainer", "owner_responsible_qa"):
             kwargs["queryset"] = User.objects.filter(hidden=False)
         return super().formfield_for_foreignkey(db_field, request, **kwargs)
+
+    def get_inline_formsets(self, request, formsets, inline_instances, obj=None):
+        """ allow to edit requirements if user have permission panopticum.change_*_status and
+        ignore change_component_version_model permission.
+        """
+        can_edit_parent = self.has_change_permission(request, obj) if obj else self.has_add_permission(request)
+        inline_admin_formsets = []
+        for inline, formset in zip(inline_instances, formsets):
+            fieldsets = list(inline.get_fieldsets(request, obj))
+            readonly = list(inline.get_readonly_fields(request, obj))
+            if can_edit_parent or issubclass(formset.model, RequirementStatusEntry):
+                has_add_permission = inline._has_add_permission(request, obj)
+                has_change_permission = inline.has_change_permission(request, obj)
+                has_delete_permission = inline.has_delete_permission(request, obj)
+            else:
+                # Disable all edit-permissions, and overide formset settings.
+                has_add_permission = has_change_permission = has_delete_permission = False
+                formset.extra = formset.max_num = 0
+            has_view_permission = inline.has_view_permission(request, obj)
+            prepopulated = dict(inline.get_prepopulated_fields(request, obj))
+            inline_admin_formset = admin.helpers.InlineAdminFormSet(
+                inline, formset, fieldsets, prepopulated, readonly, model_admin=self,
+                has_add_permission=has_add_permission, has_change_permission=has_change_permission,
+                has_delete_permission=has_delete_permission,
+                has_view_permission=has_view_permission,
+            )
+            inline_admin_formsets.append(inline_admin_formset)
+        return inline_admin_formsets
+
 
     def _clone(self, obj):
         old_depends_on = ComponentDependencyModel.objects.filter(version=obj.id).order_by('id')

--- a/panopticum/filters.py
+++ b/panopticum/filters.py
@@ -9,11 +9,18 @@ class RequirementFilter(filters.FilterSet):
         model = models.Requirement
         fields = '__all__'
 
+class ComponentVersionFilter(filters.FilterSet):
+    class Meta:
+        model = models.ComponentVersionModel
+        fields = '__all__'
 
 class RequirementStatusFilter(filters.FilterSet):
     requirement = filters.RelatedFilter(RequirementFilter,
                                         field_name='requirement',
                                         queryset=models.Requirement.objects.all())
+    component_version = filters.RelatedFilter(ComponentVersionFilter,
+                                        field_name='component_version',
+                                        queryset=models.ComponentVersionModel.objects.all())
 
     class Meta:
         model = models.RequirementStatusEntry

--- a/panopticum/fixtures/init.json
+++ b/panopticum/fixtures/init.json
@@ -186,6 +186,14 @@
     }
   },
   {
+    "model": "panopticum.requirement",
+    "pk": 18,
+    "fields": {
+      "title": "GDPR compliance",
+      "description": ""
+    }
+  },
+  {
     "model": "panopticum.requirementset",
     "pk": 1,
     "fields": {
@@ -209,7 +217,7 @@
     "fields": {
       "name": "Compliance",
       "description": "",
-      "requirements": [16, 17]
+      "requirements": [16, 17, 18]
     }
   }
 ]

--- a/panopticum/fixtures/init.json
+++ b/panopticum/fixtures/init.json
@@ -170,6 +170,22 @@
     }
   },
   {
+    "model": "panopticum.requirement",
+    "pk": 16,
+    "fields": {
+      "title": "API guideline compliance",
+      "description": ""
+    }
+  },
+  {
+    "model": "panopticum.requirement",
+    "pk": 17,
+    "fields": {
+      "title": "FIPS compliance",
+      "description": ""
+    }
+  },
+  {
     "model": "panopticum.requirementset",
     "pk": 1,
     "fields": {
@@ -185,6 +201,15 @@
       "name": "Maintenance",
       "description": "",
       "requirements": [10, 11, 12, 13, 14, 15]
+    }
+  },
+  {
+    "model": "panopticum.requirementset",
+    "pk": 3,
+    "fields": {
+      "name": "Compliance",
+      "description": "",
+      "requirements": [16, 17]
     }
   }
 ]

--- a/panopticum/models.py
+++ b/panopticum/models.py
@@ -255,7 +255,7 @@ class RequirementStatusEntry(models.Model):
     status = models.ForeignKey(RequirementStatus, on_delete=models.CASCADE)
     type = models.ForeignKey(RequirementStatusType, on_delete=models.CASCADE) # component owner or signee
     requirement = models.ForeignKey('Requirement', related_name='statuses', on_delete=models.CASCADE)
-    notes = models.TextField(null=True, blank=True, max_length=255)
+    notes = models.TextField(null=True, blank=True, max_length=16*pow(2, 10))
     component_version = models.ForeignKey('ComponentVersionModel', related_name='statuses', on_delete=models.CASCADE)
 
     class Meta:

--- a/panopticum/models.py
+++ b/panopticum/models.py
@@ -1,3 +1,4 @@
+import django.forms
 from django.db import models
 from datatableview.views import DatatableView
 from datatableview import helpers

--- a/panopticum/models.py
+++ b/panopticum/models.py
@@ -3,7 +3,7 @@ from datatableview.views import DatatableView
 from datatableview import helpers
 from django.forms.models import model_to_dict
 import datetime
-from django.contrib.auth.models import AbstractUser
+from django.contrib.auth.models import AbstractUser, Group
 from simple_history.models import HistoricalRecords
 
 import panopticum.fields
@@ -285,8 +285,10 @@ class Requirement(models.Model):
 class RequirementSet(models.Model):
     """ Container for requirements. Example of usage: various requirement widgets at frontend """
     name = models.CharField(max_length=30, unique=True)
-    requirements = models.ManyToManyField(Requirement, related_name='requirements+')
+    requirements = models.ManyToManyField(Requirement, related_name='sets')
     description = models.TextField(null=True, blank=True)
+    #
+    owner_groups = models.ManyToManyField(Group, related_name='owner_groups', blank=True)
 
     def __unicode__(self):
         return f"{self.__class__.__name__}: {self.name}"

--- a/panopticum/models.py
+++ b/panopticum/models.py
@@ -260,6 +260,10 @@ class RequirementStatusEntry(models.Model):
 
     class Meta:
         unique_together = ['status', 'type', 'component_version', 'requirement']
+        permissions = [
+            ("change_owner_status", "Can change component owner status"),
+            ("change_signee_status", "Can change signee status")
+        ]
 
     def __unicode__(self):
         return f"{self.__class__.__name__}: {self.status.name} ({self.status.type.name})"

--- a/panopticum/views.py
+++ b/panopticum/views.py
@@ -51,6 +51,7 @@ class DeploymentLocationClassViewSet(viewsets.ModelViewSet):
 class ComponentVersionViewSet(viewsets.ModelViewSet):
     queryset = ComponentVersionModel.objects.all()
     serializer_class = ComponentVersionSerializer
+    filterset_fileds = "__all__"
 
 
 class ComponentRuntimeTypeViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
**Component owner** is user who has permission "panopticum.change_owner_status". CO can edit own component versions except _signee status_ and _signee notes_. If component version maintainer does not match to current user then that component version not available for editing.

**Signee** is user who has permission "panopticum.change_signee_status".  Signee able add\change signee status and signee notes for all component versions. Signee need not to have permission "change component version". Signee available to view and edit only requirements that exist in owned requirement sets.