### PR TITLE
Requirement Status popup

### DIFF
--- a/panopticum/models.py
+++ b/panopticum/models.py
@@ -257,6 +257,7 @@ class RequirementStatusEntry(models.Model):
     requirement = models.ForeignKey('Requirement', related_name='statuses', on_delete=models.CASCADE)
     notes = models.TextField(null=True, blank=True, max_length=255)
     component_version = models.ForeignKey('ComponentVersionModel', related_name='statuses', on_delete=models.CASCADE)
+    history = HistoricalRecords()
 
     class Meta:
         unique_together = ['status', 'type', 'component_version', 'requirement']

--- a/panopticum/serializers.py
+++ b/panopticum/serializers.py
@@ -1,7 +1,7 @@
 import rest_framework.authtoken.models
 from rest_framework import serializers
 from django.contrib.auth import get_user_model
-from django.forms.models import model_to_dict
+from drf_queryfields import QueryFieldsMixin
 import panopticum.models
 from panopticum.models import *
 
@@ -70,7 +70,7 @@ class ProductVersionSerializer(serializers.ModelSerializer):
         fields = '__all__'
 
 
-class UserSerializer(serializers.ModelSerializer):
+class UserSerializer(QueryFieldsMixin, serializers.ModelSerializer):
     class Meta:
         model = get_user_model()
         exclude = ('password', )
@@ -151,6 +151,7 @@ class RequirementSerializer(DynamicFieldsModelSerializer, serializers.ModelSeria
 
 
 class RequirementStatusEntrySerializer(serializers.HyperlinkedModelSerializer):
+    id = serializers.IntegerField()
     status = serializers.SlugRelatedField(
         read_only=True,
         slug_field='name'
@@ -256,4 +257,12 @@ class TokenSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = rest_framework.authtoken.models.Token()
+        fields = '__all__'
+
+class HistoricalRequirementStatusEntrySerializer(serializers.ModelSerializer):
+    history_user = serializers.HyperlinkedRelatedField(read_only=True, view_name='user-detail')
+    requirement = serializers.HyperlinkedRelatedField(read_only=True, view_name='requirement-detail')
+    component_version = serializers.HyperlinkedRelatedField(read_only=True, view_name='componentversionmodel-detail')
+    class Meta:
+        model = getattr(panopticum.models, 'HistoricalRequirementStatusEntry')
         fields = '__all__'

--- a/panopticum/static/css/panopticum.css
+++ b/panopticum/static/css/panopticum.css
@@ -446,3 +446,7 @@ span.pa-component-stars i {
 .pointer {
     cursor: pointer;
 }
+
+.el-card__header {
+    padding: 5px 20px;
+}

--- a/panopticum/static/css/panopticum.css
+++ b/panopticum/static/css/panopticum.css
@@ -346,7 +346,7 @@ i.yes, i.no, i.unknown {
     text-align: center;
 }
 i.yes { color: green; }
-i.no { color: rgb(209, 58, 58); }
+i.no { color: rgb(209, 58, 58);}
 i.unknown { color: #aaa; }
 
 .el-popper[x-placement^=top] .popper__arrow  {
@@ -441,4 +441,8 @@ span.pa-component-stars i {
 .jira-issue-resolved span {
     text-decoration: none;
     display: inline-block;
+}
+
+.pointer {
+    cursor: pointer;
 }

--- a/panopticum/templates/page/component.html
+++ b/panopticum/templates/page/component.html
@@ -36,9 +36,6 @@
               {% include "widget/component_summary.html" %}
             </div>
             <div class="col-xs-12">
-              {% include "widget/component_activity.html" %}
-            </div>
-            <div class="col-xs-12">
               {% include "widget/component_dependency.html" %}
             </div>
           </div>
@@ -63,7 +60,6 @@
       </div>
 
     </div>
-  </div>
 
 {% endblock %}
 
@@ -85,40 +81,6 @@ var default_latest_version = {
     'owner_architect': {},
     'meta_profile_not_filled_fields': '',
 };
-
-function init_activity_chart() {
-    if ($('#activity-chart').length) {
-
-        var ctx = document.getElementById("activity-chart");
-        var chart = new Chart(ctx, {
-            type: 'bar',
-            data: {
-                labels: ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul"],
-                datasets: [{
-                    label: 'Bugs in JIRA',
-                    backgroundColor: "#26B99A",
-                    data: [51, 30, 40, 28, 92, 50, 45]
-                }, {
-                    label: 'Commits in Git',
-                    backgroundColor: "#03586A",
-                    data: [41, 56, 25, 48, 72, 34, 12]
-                }]
-            },
-
-            options: {
-                scales: {
-                    yAxes: [{
-                        ticks: {
-                            stepSize: 20,
-                            beginAtZero: true
-                        }
-                    }]
-                }
-            }
-        });
-
-    }
-}
 
 function init_rating_chart() {
     $('.chart').easyPieChart({
@@ -250,7 +212,6 @@ function update_component_page_elements(component) {
 
     init_profile_completeness_gauge(component);
     init_rating_chart();
-    init_activity_chart();
 }
 
 function vue_component_init() {

--- a/panopticum/templates/vue/widget-requirements.js
+++ b/panopticum/templates/vue/widget-requirements.js
@@ -65,15 +65,17 @@ Vue.component('widget-requirements', {
         }
     },
     template: `
-    {% verbatim %}<div>
-        <h3>{{title }}
-            <span class='pa-component-rating' v-if='component_version.op_applicable'>
-                    {{ component_version.meta_op_rating }}%
-            </span>
-            <span class='pa-component-stars' v-if='component_version.op_applicable'>
-                    {{ component_version.meta_op_rating }}
-            </span>
-        </h3>
+    {% verbatim %}<el-card>
+        <div slot="header" class="clearfix">
+            <h4><span>{{title }}</span>
+                <span class='pa-component-rating' v-if='component_version.op_applicable'>
+                        {{ component_version.meta_op_rating }}%
+                </span>
+                <span class='pa-component-stars' v-if='component_version.op_applicable'>
+                        {{ component_version.meta_op_rating }}
+                </span>
+            </h4>
+        </div>
 
         <table class='status-table' v-bind:class="[ requirements ? '' : 'status-table-na']">
             <thead>
@@ -94,6 +96,6 @@ Vue.component('widget-requirements', {
             </tr>
             </tbody>
         </table>
-    </div>{% endverbatim %}
+    </el-card>{% endverbatim %}
     `
 })

--- a/panopticum/templates/vue/widget-requirements.js
+++ b/panopticum/templates/vue/widget-requirements.js
@@ -38,14 +38,14 @@ Vue.component('widget-requirements', {
             for (let requirement of this.requirements) {
                 let ownerStatus = this.statuses.find(el => requirement.id == this.getId(el.requirement) && el.type == "component owner")
                 if (ownerStatus == undefined) {
-                    this.table.push({title: requirement.title, status: 'unknown', signoffStatus:'unknown', notes: ''})
+                    this.table.push({title: requirement.title, status: null, signoffStatus: null, notes: ''})
                 } else {
                     let signeeStatus = this.statuses.find(el => requirement.id == this.getId(el.requirement) && el.type == "requirement reviewer")
                     this.table.push({
                         title: requirement.title,
-                        status: ownerStatus.status, 
+                        status: ownerStatus, 
                         notes: ownerStatus.notes,
-                        signoffStatus: signeeStatus.status,
+                        signoffStatus: signeeStatus,
                         signoffNotes: signeeStatus.notes
                     })
                 }

--- a/panopticum/templates/vue/widget-signoff.js
+++ b/panopticum/templates/vue/widget-signoff.js
@@ -1,35 +1,72 @@
 Vue.component('widget-signoff', {
-  props: ['status', 'history', 'signoff-status'],
+  props: ['status', 'signoff-status'],
   computed: {
-      classObject: function() {
-        return {
-          'el-icon-success yes': this.status == 'yes',
-          'el-icon-error no': this.status == 'no',
-          'unknown': this.status == 'n/a',
-          'el-icon-question': this.status == 'unknown' || !this.status 
-        }
+    classObject: function() {
+      return {
+        'el-icon-success yes': this.status && this.status.status == 'yes',
+        'el-icon-error no': this.status && this.status.status == 'no',
+        'unknown': this.status && this.status.status == 'n/a',
+        'el-icon-question': !this.status || this.status.status == 'unknown',
+        'pointer': this.popupEnabled
       }
+    },
+    apiUrl: function() {
+      return `${window.location.origin}/api`
+    },
+    popupEnabled: function() {
+      return this.status && (this.status.notes || this.history)
+    }
   },
-  template: `
-    {% verbatim %}<span>
-      <el-popover
-                  v-if="['yes', 'no', 'n/a'].includes(status) && history"
-                  placement="top-end"
-                  width="200"
-                  trigger="click"
-                  popper-class="signoff-popover"
-            >
-              <div>Updated by {{ history.user.username }} <br/>
-              at {{ history.date }}</div>
-              <span v-bind:class="classObject" slot="reference" style="cursor: pointer">
-                {{ status.toUpperCase() }}
-              </span>
-      </el-popover>
-      <i v-else-if="['yes', 'no'].includes(status) && !history" v-bind:class="classObject" style="font-size: 16px;"></i>
-      <i v-else-if="['n/a'].includes(status) && !history" v-bind:class="classObject" style="font-size: 12px;">
+  data: function() {
+    return {
+      'history': null,
+    }
+  },
+  watch: {
+    history: function() {
+      console.log(this.history.user);
+    }
+  },
+  mounted: function() {
+    if (this.status) this.updateLastChange(this.status);
+  },
+  methods: {
+    updateLastChange: function(status) {
+      return axios.get(`${status.url}history/?limit=1`)
+      .then(resp => {
+        if (resp.data.count > 0) {
+          this.history = resp.data.results[0];
+          axios.get(this.history.history_user).then(resp => this.history.user = resp.data)
+        }
+      })
+    },
+    formatDate: function(date) {
+      return new Date(Date.parse(date)).toLocaleString('en-US', 
+                                                       {month: 'long', 
+                                                       year: 'numeric', 
+                                                       day: 'numeric', 
+                                                       hour: 'numeric', 
+                                                       minute: 'numeric', 
+                                                       second: 'numeric'})
+    }
+  },
+  template: `{% verbatim %}
+  <el-popover
+              placement="top-end"
+              width="250"
+              trigger="click"
+              popper-class="signoff-popover"
+              v-bind:disabled = "!popupEnabled"
+  >
+    <div v-if="history && history.user">Updated by {{ history.user }} <br/>
+    at {{ formatDate(history.history_date) }}</div>
+    <span slot="reference" >
+      <i v-if="status && ['yes', 'no'].includes(status.status)" v-bind:class="classObject" style="font-size: 16px;"></i>
+      <i v-else-if="status && ['n/a'].includes(status.status)" v-bind:class="classObject" style="font-size: 12px;">
       N/A
-</i>
+      </i>
       <i v-else class="el-icon-question" style="color: grey;font-size: 16px;"></i>
-    </span>{% endverbatim %}
+    </span>
+  </el-popover>{% endverbatim %}
   `
 })

--- a/panopticum/templates/widget/component_dependency.html
+++ b/panopticum/templates/widget/component_dependency.html
@@ -1,83 +1,41 @@
-    <div class="x_panel tile">
-      <div class="x_title">
-        <h2>Dependencies</h2>
-        <ul class="nav navbar-right panel_toolbox">
-          <li><a class="collapse-link"><i class="fa fa-chevron-up"></i></a></li>
-          <li><a class="close-link"><i class="fa fa-close"></i></a></li>
-        </ul>
-        <div class="clearfix"></div>
-      </div>
-      <div class='x_content'>
+<el-card v-if="component.latest_version.depends_on && component.latest_version.depends_on.length">
+  <div slot="header" class="clearfix">
+    <h2>Dependencies</h2>
+  </div>
 
-        <div class='row'>
-          <div class='col-sm-12'>
+  <h4>Services</h4>
+  <table class='status-table' v-cloak>
+    <thead>
+      <tr>
+        <th>Service</th>
+        <th>Dependency</th>
+        <th>Notes</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr v-for='item in component.latest_version.depends_on' v-if="item.type !== 'includes'" v-cloak>
+        <td><a v-bind:href="'/component/' + item.component.id">[[ item.component.name ]]</a></td>
+        <td class='pa-dependency'>[[ item.type ]]</td>
+        <td class='pa-replace-urls'>[[ item.notes ]]</td>
+      </tr>
+    </tbody>
+  </table>
 
-            <h3>Services</h3>
-            <table class='status-table' v-cloak>
-              <thead>
-                <tr>
-                  <th>Service</th>
-                  <th>Dependency</th>
-                  <th>Notes</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr v-for='item in component.latest_version.depends_on' v-if="item.type !== 'includes'" v-cloak>
-                  <td><a v-bind:href="'/component/' + item.component.id">[[ item.component.name ]]</a></td>
-                  <td class='pa-dependency'>[[ item.type ]]</td>
-                  <td class='pa-replace-urls'>[[ item.notes ]]</td>
-                </tr>
-              </tbody>
-            </table>
-
-            <h3>Libraries</h3>
-            <table class='status-table' v-cloak>
-              <thead>
-                <tr>
-                  <th>Library</th>
-                  <th>Vendor</th>
-                  <th>Notes</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr v-for='item in component.latest_version.depends_on' v-if="item.type === 'includes'" v-cloak>
-                  <td>[[ item.component.name ]]</td>
-                  <td>[[ item.component.vendor.name ]]</td>
-                  <td class='pa-replace-urls'>[[ item.notes ]]</td>
-                </tr>
-              </tbody>
-            </table>
-
-          </div>
-        </div>
-
-        <br>
-
-        <div class='row panopticum-side-by-side-table row-eq-height-xl row-eq-height-lg row-neq-height-md row-neq-height-sm row-eq-height-xs' style='opacity: 0.5;'>
-          <div class='col-xl-6 col-lg-6 col-md-12 col-sm-12 col-xs-6'>
-            <div>
-              <h4>RDBMS (TODO)</h4>
-              <table class='col-3-center'>
-                <tr><td>Supported DBs</td><td>:</td><td>-</td></tr>
-                <tr><td>ORM</td><td>:</td><td>-</td></tr>
-                <tr><td>DB conn pool</td><td>:</td><td>-</td></tr>
-                <tr><td>Volume model</td><td>:</td><td>-</td></tr>
-                <tr><td>Data retention</td><td>:</td><td>-</td></tr>
-              </table>
-            </div>
-          </div>
-          <div class='col-xl-6 col-lg-6 col-md-12 col-sm-12 col-xs-6'>
-            <div>
-              <h4>NoSQL (TODO)</h4>
-              <table class='col-3-center'>
-                <tr><td>Supported DBs</td><td>:</td><td>-</td></tr>
-                <tr><td>ORM</td><td>:</td><td>-</td></tr>
-                <tr><td>DB conn pool</td><td>:</td><td>-</td></tr>
-                <tr><td>Volume model</td><td>:</td><td>-</td></tr>
-                <tr><td>Data retention</td><td>:</td><td>-</td></tr>
-              </table>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
+  <h4>Libraries</h4>
+  <table class='status-table' v-cloak>
+    <thead>
+      <tr>
+        <th>Library</th>
+        <th>Vendor</th>
+        <th>Notes</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr v-for='item in component.latest_version.depends_on' v-if="item.type === 'includes'" v-cloak>
+        <td>[[ item.component.name ]]</td>
+        <td>[[ item.component.vendor.name ]]</td>
+        <td class='pa-replace-urls'>[[ item.notes ]]</td>
+      </tr>
+    </tbody>
+  </table>
+</el-card>

--- a/panopticum/templates/widget/component_deployments.html
+++ b/panopticum/templates/widget/component_deployments.html
@@ -1,67 +1,30 @@
-        <div class="x_panel">
-          <div class="x_title">
-            <h2>Deployments</h2>
-            <ul class="nav navbar-right panel_toolbox">
-              <li><a class="collapse-link"><i class="fa fa-chevron-up"></i></a></li>
-              <li><a class="close-link"><i class="fa fa-close"></i></a></li>
-            </ul>
-            <div class="clearfix"></div>
-          </div>
+<el-card v-if="component.latest_version.deployments && component.latest_version.deployments.length">
+  <div slot="header" class="clearfix">
+    <h2>Deployments</h2>
+  </div>
 
-          <div class="x_content">
+    <h4>Deployment Types</h4>
+    <table class='status-table table-auto-width' v-cloak>
+      <thead>
+        <tr>
+          <th>Product</th>
+          <th>Location</th>
+          <th>Env</th>
+          <th>Service</th>
+          <th>Ports</th>
+          <th>Notes</th>
+        </tr>
+      </thead>
 
-            <h3>Deployment Types</h3>
-            <table class='status-table table-auto-width' v-cloak>
-              <thead>
-                <tr>
-                  <th>Product</th>
-                  <th>Location</th>
-                  <th>Env</th>
-                  <th>Service</th>
-                  <th>Ports</th>
-                  <th>Notes</th>
-                </tr>
-              </thead>
-
-              <tbody>
-                <tr v-for='d in component.latest_version.deployments'>
-                  <td v-tooltip:right="[[ d.product_version.name ]]">[[ d.product_version.shortname]]</td>
-                  <td>[[ d.location_class.name ]]</td>
-                  <td>[[ d.environment.name ]]</td>
-                  <td>[[ d.service_name ]] [[ d.binary_name ]]</td>
-                  <td>[[ d.open_ports ]]</td>
-                  <td class='pa-replace-urls'>[[ d.notes ]]</td>
-                </tr>
-              </tbody>
-            </table>
-
-            <div style='opacity: 0.5; padding-top: 15px;'>
-            <h3>Cloud deployments (TODO)</h3>
-            <table class='status-table table-auto-width'>
-              <thead>
-                <tr class='auto-width'>
-                  <th>Datacenter</th>
-                  <th>Y/N</th>
-                  <th>Metrics</th>
-                  <th>Logs</th>
-                  <th>Alerts</th>
-                  <th>Notes</th>
-                </tr>
-              </thead>
-
-              <tbody>
-                <tr><td>US1</td><td>YES</td><td><a href="#">metrics</a></td><td>-</td><td>-</td><td>-</td></tr>
-                <tr><td>US2</td><td>YES</td><td><a href="#">metrics</a></td><td>-</td><td>-</td><td>-</td></tr>
-                <tr><td>US3</td><td>YES</td><td><a href="#">metrics</a></td><td>-</td><td>-</td><td>-</td></tr>
-                <tr><td>US4</td><td>YES</td><td><a href="#">metrics</a></td><td>-</td><td>-</td><td>-</td></tr>
-                <tr><td>EU1</td><td>YES</td><td><a href="#">metrics</a></td><td><a href="#">logs</a></td><td>-</td><td>-</td></tr>
-                <tr><td>EU2</td><td>YES</td><td><a href="#">metrics</a></td><td><a href="#">logs</a></td><td>-</td><td>-</td></tr>
-                <tr><td>AU1</td><td>YES</td><td><a href="#">metrics</a></td><td>-</td><td><a href="#">alerts</a></td><td>-</td></tr>
-                <tr><td>XG1</td><td>No</td><td><a href="#">-</a></td><td>-</td><td>-</td><td>-</td></tr>
-                <tr><td>XG2</td><td>No</td><td><a href="#">-</a></td><td>-</td><td>-</td><td>-</td></tr>
-              </tbody>
-            </table>
-            </div>
-
-          </div>
-        </div>
+      <tbody>
+        <tr v-for='d in component.latest_version.deployments'>
+          <td v-tooltip:right="[[ d.product_version.name ]]">[[ d.product_version.shortname]]</td>
+          <td>[[ d.location_class.name ]]</td>
+          <td>[[ d.environment.name ]]</td>
+          <td>[[ d.service_name ]] [[ d.binary_name ]]</td>
+          <td>[[ d.open_ports ]]</td>
+          <td class='pa-replace-urls'>[[ d.notes ]]</td>
+        </tr>
+      </tbody>
+    </table>
+</el-card>

--- a/panopticum/templates/widget/component_owners.html
+++ b/panopticum/templates/widget/component_owners.html
@@ -1,122 +1,115 @@
 {% load static %}
-        <div class="x_panel">
-          <div class="x_title">
-            <h2>Owners</h2>
-            <ul class="nav navbar-right panel_toolbox">
-              <li><a class="collapse-link"><i class="fa fa-chevron-up"></i></a></li>
-              <li><a class="close-link"><i class="fa fa-close"></i></a></li>
-            </ul>
-            <div class="clearfix"></div>
-          </div>
-          <div class="x_content">
-            <div class="owners-list">
+<el-card>
+  <div slot="header" class="clearfix">
+    <h2>Owners</h2>
+  </div>
+    <div class="owners-list">
 
-              <table style='width: 100%;' v-cloak>
-              <tr>
-                <td class='owner'>
-                  <div class='block'>
-                    <div class='image'>
-                      <img v-bind:src="component.latest_version.owner_maintainer.photo" v-if="component.latest_version.owner_maintainer">
-                      <img v-else src="{% static '/images/default_avatar.png' %}">
-                    </div>
-                    <div class='details'>
-                      <b v-if='component.latest_version.owner_maintainer'>
-                        [[ component.latest_version.owner_maintainer.name ]]</b> - Maintainer<br>
-                      <a v-if='component.latest_version.owner_maintainer'
-                         v-bind:href="`mailto:${component.latest_version.owner_maintainer.email}`">
-                        [[ component.latest_version.owner_maintainer.email ]], </a>
-                      <span v-if='component.latest_version.owner_maintainer'>
-                        [[ component.latest_version.owner_maintainer.mobile_phone ]]</span>
-                    </div>
-                  </div>
-                </td>
-              </tr>
-
-              <tr>
-                <td class='owner'>
-                  <div class='block'>
-                    <div class='image'>
-                      <img v-bind:src="component.latest_version.owner_responsible_qa.photo" v-if="component.latest_version.owner_responsible_qa">
-                      <img v-else src="{% static '/images/default_avatar.png' %}">
-                    </div>
-                    <div class='details'>
-                      <b v-if='component.latest_version.owner_responsible_qa'>
-                        [[ component.latest_version.owner_responsible_qa.name ]]</b> - Responsible QA<br>
-                      <a v-if='component.latest_version.owner_responsible_qa'
-                         v-bind:href="`mailto:${component.latest_version.owner_responsible_qa.email}`">
-                        [[ component.latest_version.owner_responsible_qa.email ]], </a>
-                      <span v-if='component.latest_version.owner_responsible_qa'>
-                        [[ component.latest_version.owner_responsible_qa.mobile_phone ]]</span>
-                    </div>
-                  </div>
-                </td>
-              </tr>
-
-              <tr v-for="p in component.latest_version.owner_product_manager">
-                <td class='owner'>
-                  <div class='block'>
-                    <div class='image'><img v-bind:src="p.photo"></div>
-                    <div class='details'>
-                      <b>[[ p.name ]]</b> - Product Manager<br>
-                      <a v-bind:href="`mailto:${p.email}`">[[ p.email ]]</a>, [[ p.mobile_phone ]]
-                    </div>
-                  </div>
-                </td>
-              </tr>
-
-              <tr v-for="p in component.latest_version.owner_program_manager">
-                <td class='owner'>
-                  <div class='block'>
-                    <div class='image'><img v-bind:src="p.photo"></div>
-                    <div class='details'>
-                      <b>[[ p.name ]]</b> - Program Manager<br>
-                      <a v-bind:href="`mailto:${p.email}`">[[ p.email ]]</a>, [[ p.mobile_phone ]]
-                    </div>
-                  </div>
-                </td>
-              </tr>
-
-              <tr v-for="p in component.latest_version.owner_architect">
-                <td class='owner'>
-                  <div class='block'>
-                    <div class='image'><img v-bind:src="p.photo"></div>
-                    <div class='details'>
-                      <b>[[ p.name ]]</b> - Architect<br>
-                      <a v-bind:href="`mailto:${p.email}`">[[ p.email ]]</a>, [[ p.mobile_phone ]]
-                    </div>
-                  </div>
-                </td>
-              </tr>
-
-              <tr>
-                <td class='owner'>
-                  <div class='block'>
-                    <div class='image'><i class='fa fa-phone'></i></div>
-                    <div class='details' style='min-height: 42px;'>
-                      <b>Escalation list:</b><br>
-                      <div v-for="p in component.latest_version.owner_escalation_list">
-                        <a v-bind:href="`mailto:${p.email}`">[[ p.email ]]</a>, [[ p.mobile_phone ]]
-                      </div>
-                    </div>
-                  </div>
-                </td>
-              </tr>
-
-              <tr>
-                <td class='owner'>
-                  <div class='block'>
-                    <div class='image'><i class='fa fa-question'></i></div>
-                    <div class='details' style='min-height: 42px;'>
-                      <b>Experts:</b><br>
-                      <div v-for="p in component.latest_version.owner_expert">
-                        <a v-bind:href="`mailto:${p.email}`">[[ p.email ]]</a>, [[ p.mobile_phone ]]
-                      </div>
-                    </div>
-                  </div>
-                </td>
-              </tr>
-
-              </table>
+      <table style='width: 100%;' v-cloak>
+      <tr>
+        <td class='owner'>
+          <div class='block'>
+            <div class='image'>
+              <img v-bind:src="component.latest_version.owner_maintainer.photo" v-if="component.latest_version.owner_maintainer">
+              <img v-else src="{% static '/images/default_avatar.png' %}">
+            </div>
+            <div class='details'>
+              <b v-if='component.latest_version.owner_maintainer'>
+                [[ component.latest_version.owner_maintainer.name ]]</b> - Maintainer<br>
+              <a v-if='component.latest_version.owner_maintainer'
+                  v-bind:href="`mailto:${component.latest_version.owner_maintainer.email}`">
+                [[ component.latest_version.owner_maintainer.email ]], </a>
+              <span v-if='component.latest_version.owner_maintainer'>
+                [[ component.latest_version.owner_maintainer.mobile_phone ]]</span>
             </div>
           </div>
-        </div>
+        </td>
+      </tr>
+
+      <tr>
+        <td class='owner'>
+          <div class='block'>
+            <div class='image'>
+              <img v-bind:src="component.latest_version.owner_responsible_qa.photo" v-if="component.latest_version.owner_responsible_qa">
+              <img v-else src="{% static '/images/default_avatar.png' %}">
+            </div>
+            <div class='details'>
+              <b v-if='component.latest_version.owner_responsible_qa'>
+                [[ component.latest_version.owner_responsible_qa.name ]]</b> - Responsible QA<br>
+              <a v-if='component.latest_version.owner_responsible_qa'
+                  v-bind:href="`mailto:${component.latest_version.owner_responsible_qa.email}`">
+                [[ component.latest_version.owner_responsible_qa.email ]], </a>
+              <span v-if='component.latest_version.owner_responsible_qa'>
+                [[ component.latest_version.owner_responsible_qa.mobile_phone ]]</span>
+            </div>
+          </div>
+        </td>
+      </tr>
+
+      <tr v-for="p in component.latest_version.owner_product_manager">
+        <td class='owner'>
+          <div class='block'>
+            <div class='image'><img v-bind:src="p.photo"></div>
+            <div class='details'>
+              <b>[[ p.name ]]</b> - Product Manager<br>
+              <a v-bind:href="`mailto:${p.email}`">[[ p.email ]]</a>, [[ p.mobile_phone ]]
+            </div>
+          </div>
+        </td>
+      </tr>
+
+      <tr v-for="p in component.latest_version.owner_program_manager">
+        <td class='owner'>
+          <div class='block'>
+            <div class='image'><img v-bind:src="p.photo"></div>
+            <div class='details'>
+              <b>[[ p.name ]]</b> - Program Manager<br>
+              <a v-bind:href="`mailto:${p.email}`">[[ p.email ]]</a>, [[ p.mobile_phone ]]
+            </div>
+          </div>
+        </td>
+      </tr>
+
+      <tr v-for="p in component.latest_version.owner_architect">
+        <td class='owner'>
+          <div class='block'>
+            <div class='image'><img v-bind:src="p.photo"></div>
+            <div class='details'>
+              <b>[[ p.name ]]</b> - Architect<br>
+              <a v-bind:href="`mailto:${p.email}`">[[ p.email ]]</a>, [[ p.mobile_phone ]]
+            </div>
+          </div>
+        </td>
+      </tr>
+
+      <tr>
+        <td class='owner'>
+          <div class='block'>
+            <div class='image'><i class='fa fa-phone'></i></div>
+            <div class='details' style='min-height: 42px;'>
+              <b>Escalation list:</b><br>
+              <div v-for="p in component.latest_version.owner_escalation_list">
+                <a v-bind:href="`mailto:${p.email}`">[[ p.email ]]</a>, [[ p.mobile_phone ]]
+              </div>
+            </div>
+          </div>
+        </td>
+      </tr>
+
+      <tr>
+        <td class='owner'>
+          <div class='block'>
+            <div class='image'><i class='fa fa-question'></i></div>
+            <div class='details' style='min-height: 42px;'>
+              <b>Experts:</b><br>
+              <div v-for="p in component.latest_version.owner_expert">
+                <a v-bind:href="`mailto:${p.email}`">[[ p.email ]]</a>, [[ p.mobile_phone ]]
+              </div>
+            </div>
+          </div>
+        </td>
+      </tr>
+
+      </table>
+    </div>
+</el-card>

--- a/panopticum/templates/widget/component_ratings.html
+++ b/panopticum/templates/widget/component_ratings.html
@@ -1,51 +1,32 @@
-        <div class="x_panel tile">
-          <div class="x_title">
-            <h2>Ratings</h2>
+<el-card>
+  <div slot="header" class="clearfix">
+    <h3 v-cloak>Quality Assurance
+      <span class='pa-component-rating' v-cloak v-if='component.latest_version.qa_applicable'>
+        [[ component.latest_version.meta_qa_rating ]]%
+      </span>
+      <span class='pa-component-stars' v-cloak v-if='component.latest_version.qa_applicable'>
+        [[ component.latest_version.meta_qa_rating ]]
+      </span>
+    </h3>
+  </div>
 
-            <ul class="nav navbar-right panel_toolbox">
-              <li><a class="collapse-link"><i class="fa fa-chevron-up"></i></a></li>
-              <li><a class="close-link"><i class="fa fa-close"></i></a></li>
-            </ul>
-            <div class="clearfix"></div>
-          </div>
-          <div class="x_content" style='margin-top: 0px;'>
-
-<!--
-   <canvas id="ratings-chart" height="150" width="500" style="width: 500px; height: 150px; padding-top: 0px;"></canvas>
-//-->
-
-            <h3 v-cloak>Quality Assurance
-              <span class='pa-component-rating' v-cloak v-if='component.latest_version.qa_applicable'>
-                [[ component.latest_version.meta_qa_rating ]]%
-              </span>
-              <span class='pa-component-stars' v-cloak v-if='component.latest_version.qa_applicable'>
-                [[ component.latest_version.meta_qa_rating ]]
-              </span>
-            </h2>
-
-            <table class='status-table' v-bind:class="[ component.latest_version.qa_applicable ? '' : 'status-table-na']" v-cloak>
-              <thead>
-                <tr>
-                  <th>Test type</th>
-                  <th>Rating</th>
-                  <th>Notes</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr v-for='item in component.latest_version.quality_assurance' v-cloak>
-                  <td>[[ item.title ]]</td>
-                  <td class='pa-quality'>[[ item.status ]]</td>
-                  <td class='pa-replace-urls'>[[ item.notes ]]</td>
-                </tr>
-              </tbody>
-            </table>
-            <widget-requirements setid="1" v-bind:component_version="component.latest_version" v-cloak></widget-requirements>
-            <widget-requirements setid="2" v-bind:component_version="component.latest_version" v-cloak></widget-requirements>
-            <widget-requirements setid="3" v-bind:component_version="component.latest_version" v-cloak></widget-requirements>
-
-
-
-
-
-          </div>
-        </div>
+  <table class='status-table' v-bind:class="[ component.latest_version.qa_applicable ? '' : 'status-table-na']" v-cloak>
+    <thead>
+      <tr>
+        <th>Test type</th>
+        <th>Rating</th>
+        <th>Notes</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr v-for='item in component.latest_version.quality_assurance' v-cloak>
+        <td>[[ item.title ]]</td>
+        <td class='pa-quality'>[[ item.status ]]</td>
+        <td class='pa-replace-urls'>[[ item.notes ]]</td>
+      </tr>
+    </tbody>
+  </table>
+</el-card>
+<widget-requirements setid="1" v-bind:component_version="component.latest_version" v-cloak></widget-requirements>
+<widget-requirements setid="2" v-bind:component_version="component.latest_version" v-cloak></widget-requirements>
+<widget-requirements setid="3" v-bind:component_version="component.latest_version" v-cloak></widget-requirements>

--- a/panopticum/templates/widget/component_summary.html
+++ b/panopticum/templates/widget/component_summary.html
@@ -1,21 +1,12 @@
-    <div class="x_panel tile">
-      <div class="x_title">
-        <h2>Summary</h2>
-        <ul class="nav navbar-right panel_toolbox">
-          <li><a class="collapse-link"><i class="fa fa-chevron-up"></i></a></li>
-          <li><a class="close-link"><i class="fa fa-close"></i></a></li>
-        </ul>
-        <div class="clearfix"></div>
-      </div>
-      <div class='x_content'>
-
+    <el-card class="box-card">
+        <div slot="header" class="clearfix"><h2>Summary</h2></div>
         <div class='row' v-cloak v-if='component.description'>
           <div class='col-sm-12' style='padding: 0px 5px 15px 5px;'>
               <h3 style='margin-bottom: 10px;'>Component Description</h3>
               [[ component.description ]]
           </div>
         </div>
-        <div class='row panopticum-side-by-side-table row-eq-height-xl row-eq-height-lg row-neq-height-md row-neq-height-sm row-eq-height-xs'>
+        <div class='panopticum-side-by-side-table'>
           <div class='col-xl-6 col-lg-6 col-md-12 col-sm-12 col-xs-6'>
             <div>
               <h4>Development</h4>
@@ -49,6 +40,4 @@
             </div>
           </div>
         </div>
-
-      </div>
-    </div>
+      </el-card>

--- a/panopticum/views.py
+++ b/panopticum/views.py
@@ -81,6 +81,20 @@ class RequirementStatusViewSet(viewsets.ModelViewSet):
     filter_class = panopticum.filters.RequirementStatusFilter
     filterset_fields = '__all__'
 
+    @action(detail=True)
+    def history(self, request, pk=None):
+        status = self.get_object()
+        history_entries = status.history.all()
+        page = self.paginate_queryset(history_entries)
+        if page is not None:
+            serializer = HistoricalRequirementStatusEntrySerializer(page, many=True,
+                                                                    context={'request': request})
+            return self.get_paginated_response(serializer.data)
+
+        serializer = HistoricalRequirementStatusEntrySerializer(history_entries, many=True,
+                                                                context={'request': request})
+        return Response(serializer.data)
+
 
 class RequirementSetViewSet(viewsets.ModelViewSet):
     queryset = RequirementSet.objects.all()

--- a/panopticum_django/settings.py
+++ b/panopticum_django/settings.py
@@ -64,7 +64,7 @@ REST_FRAMEWORK = {
         'rest_framework_filters.backends.RestFrameworkFilterBackend',
         'rest_framework_datatables.filters.DatatablesFilterBackend',
     ),
-    'DEFAULT_PAGINATION_CLASS': 'rest_framework_datatables.pagination.DatatablesPageNumberPagination',
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
     'PAGE_SIZE': 50,
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ django-modeladmin-reorder
 django-simple-history
 djangorestframework-datatables
 djangorestframework-filters==1.0.0.dev0
+djangorestframework-queryfields
 gevent
 gunicorn
 jira-python


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3967080/74036677-c4607300-49cd-11ea-9e33-3fbd0bf06442.png)
Popup available on click at requirement signee status if history available. Widget produce 1-2 requests per status: request for status history and user details. At this moment we have some overhead with similar requests for similar users. That will be solved with [vuex](https://vuex.vuejs.org) at next milestone.

Also widgets was migrated to [el-card](https://element.eleme.io/#/en-US/component/card)