### PR TITLE
Present JIRA links and common links at notes

### DIFF
--- a/panopticum/models.py
+++ b/panopticum/models.py
@@ -718,4 +718,8 @@ class DatacenterModel(models.Model):
 
 
 class JiraIssue(django_atlassian.models.djira.Issue):
-    pass
+    def save(self, *args, **kwargs):
+        return
+
+    def delete(self, *args, **kwargs):
+        return

--- a/panopticum/models.py
+++ b/panopticum/models.py
@@ -6,6 +6,7 @@ from django.forms.models import model_to_dict
 import datetime
 from django.contrib.auth.models import AbstractUser, Group
 from simple_history.models import HistoricalRecords
+import django_atlassian.models.djira
 
 import panopticum.fields
 
@@ -714,3 +715,7 @@ class DatacenterModel(models.Model):
 
     def __str__(self):
         return "%s" % self.name
+
+
+class JiraIssue(django_atlassian.models.djira.Issue):
+    pass

--- a/panopticum/serializers.py
+++ b/panopticum/serializers.py
@@ -6,6 +6,7 @@ import panopticum.models
 from drf_queryfields import QueryFieldsMixin
 from panopticum.models import *
 
+
 class DynamicFieldsModelSerializer(serializers.ModelSerializer):
     """
     A ModelSerializer that takes an additional `fields` argument that
@@ -247,7 +248,6 @@ class ComponentVersionSerializerSimple(serializers.ModelSerializer):
         exclude = ComponentVersionModel.get_quality_assurance_fields()
 
 
-
 class ComponentVersionSerializer(QueryFieldsMixin, ComponentVersionSerializerSimple):
     component = ComponentSerializerSimple(read_only=True)
     rating = serializers.FloatField(read_only=True)
@@ -265,12 +265,20 @@ class ComponentVersionSerializer(QueryFieldsMixin, ComponentVersionSerializerSim
         return ret
 
 
+class IssueSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = JiraIssue
+        fields = ['assignee', 'reporter', 'summary', 'description',
+                  'project', 'issue_type', 'component_s', 'fix_version_s', 'status']
+
+
 class TokenSerializer(serializers.ModelSerializer):
     user = UserSerializer(read_only=True)
 
     class Meta:
         model = rest_framework.authtoken.models.Token()
         fields = '__all__'
+
 
 class HistoricalRequirementStatusEntrySerializer(serializers.ModelSerializer):
     history_user = serializers.HyperlinkedRelatedField(read_only=True, view_name='user-detail')

--- a/panopticum/serializers.py
+++ b/panopticum/serializers.py
@@ -266,10 +266,14 @@ class ComponentVersionSerializer(QueryFieldsMixin, ComponentVersionSerializerSim
 
 
 class IssueSerializer(serializers.ModelSerializer):
+    type = serializers.StringRelatedField(source='issue_type')
+    components = serializers.ListField(serializers.StringRelatedField, source='component_s')
+    fixVersion = serializers.ListField(serializers.StringRelatedField, source='fix_version_s')
+
     class Meta:
         model = JiraIssue
         fields = ['assignee', 'reporter', 'summary', 'description',
-                  'project', 'issue_type', 'component_s', 'fix_version_s', 'status']
+                  'project', 'type', 'components', 'fixVersion', 'status']
 
 
 class TokenSerializer(serializers.ModelSerializer):

--- a/panopticum/static/css/panopticum.css
+++ b/panopticum/static/css/panopticum.css
@@ -505,6 +505,20 @@ div.owner {
     top: 0px;
 }
 
+.fixVersion {
+    display: inline-block;
+    border-radius: 4px;
+    padding: 1px;
+    text-align: center;
+    margin: 0px 2px;
+    color: white;
+    background-color: grey;
+}
+
+.closedIssue {
+    text-decoration: 'line-through';
+}
+
 .signee-no {
     background-color: #F5B7B1 !important;
 }

--- a/panopticum/templates/dashboard/team.html
+++ b/panopticum/templates/dashboard/team.html
@@ -30,7 +30,8 @@
 $(document).ready(function() {
 
     ELEMENT.locale(ELEMENT.lang.en);
- 
+    {% include "vue/widget-note.js" %}
+    {% include "vue/widget-jira-ticket.js" %}
     {% include "vue/status.js" %}
     {% include "vue/wdget-status-popover.js" %}
     {% include "vue/widget-components-list.js" %}

--- a/panopticum/templates/page/component.html
+++ b/panopticum/templates/page/component.html
@@ -231,6 +231,8 @@ function update_component_page_elements(component) {
 function vue_component_init() {
 
     var url = `/api${window.location.pathname}/?format=json`
+    {% include "vue/widget-jira-ticket.js" %}
+    {% include "vue/widget-note.js" %}
     {% include "vue/status.js" %}
     {% include "vue/widget-requirements.js" %}
     {% include "vue/widget-signoff.js" %}

--- a/panopticum/templates/vue/wdget-status-popover.js
+++ b/panopticum/templates/vue/wdget-status-popover.js
@@ -96,12 +96,12 @@ Vue.component('widget-status-popover', {
             </div>
             <div v-if="status.history && status.user">
                 <div class="text item">Status: {{ status.status.name }}
-                    <app-status :status="status.status" lightIcon v-if="status.type=='requirement reviewer'"></app-status>
-                    <div :class="getSigneeClass(status)" v-if="status.type=='component owner'" style="width: 40px; height: 1em; border: 1px solid darkgrey; display: inline-block"></div>
+                    <app-status :status="status.status" lightIcon v-if="status.type=='component owner'"></app-status>
+                    <div :class="getSigneeClass(status)" v-if="status.type=='requirement reviewer'" style="width: 40px; height: 1em; border: 1px solid darkgrey; display: inline-block"></div>
                 </div>
                 <div class="text item">updated by <span style="font-weight: bold">{{ getUsername(status.user) }}</span></div>
                 <div class="text item">{{ formatDate(status.history.history_date) }}</div>
-                <div class="text item" v-if="status && status.notes">{{ status.notes }}</div>
+                <div class="text item" v-if="status && status.notes"><widget-note>{{ status.notes }}</widget-note></div>
             </div>
         </el-card>
         <span slot="reference">

--- a/panopticum/templates/vue/widget-components-list.js
+++ b/panopticum/templates/vue/widget-components-list.js
@@ -463,7 +463,7 @@ Vue.component('widget-components-list', {
                      v-if="displayPopover(scope.row[req.title].owner, scope.row[req.title].signee)">
                         <div class="inner-cell">
                             <span class="word-wrap" v-if="scope.row[req.title].owner && scope.row[req.title].owner.notes && scope.row[req.title].owner.status.name !='n/a'">
-                            <widget-note>{{ scope.row[req.title].owner.notes }}</widget-note>
+                            <widget-note :short="true">{{ scope.row[req.title].owner.notes }}</widget-note>
                             </span>
                             <div class="fill-cell" v-else></div>
                         </div>

--- a/panopticum/templates/vue/widget-components-list.js
+++ b/panopticum/templates/vue/widget-components-list.js
@@ -463,7 +463,7 @@ Vue.component('widget-components-list', {
                      v-if="displayPopover(scope.row[req.title].owner, scope.row[req.title].signee)">
                         <div class="inner-cell">
                             <span class="word-wrap" v-if="scope.row[req.title].owner && scope.row[req.title].owner.notes && scope.row[req.title].owner.status.name !='n/a'">
-                            {{ scope.row[req.title].owner.notes }}
+                            <widget-note>{{ scope.row[req.title].owner.notes }}</widget-note>
                             </span>
                             <div class="fill-cell" v-else></div>
                         </div>

--- a/panopticum/templates/vue/widget-requirements.js
+++ b/panopticum/templates/vue/widget-requirements.js
@@ -109,7 +109,7 @@ Vue.component('widget-requirements', {
 
                 <td><widget-signoff v-bind:status="row.status" v-bind:signoff-status="row.signoffStatus"></widget-signoff></td>
                 <td><widget-signoff v-bind:status="row.signoffStatus"></widget-signoff></td>
-                <td class='pa-replace-urls'>{{ row.notes }}</td>
+                <td class='pa-replace-urls'><widget-note :short="true">{{ row.notes }}</widget-note></td>
             </tr>
             </tbody>
         </table>

--- a/panopticum_django/settings.py
+++ b/panopticum_django/settings.py
@@ -49,7 +49,8 @@ INSTALLED_APPS = [
     'admin_reorder',
     'simple_history',
     'loginas',
-    'panopticum'
+    'django_atlassian',
+    'panopticum',
 ]
 
 REST_FRAMEWORK = {
@@ -117,13 +118,18 @@ DATABASES = {
         'HOST': os.environ.get('DB_HOST', None),
         'PORT': os.environ.get('DB_PORT', None),
         'CONN_MAX_AGE': os.environ.get('DB_CONN_MAX_AGE', 0),
-    }
+    },
+    'jira': {
+            'ENGINE': 'django_atlassian.backends.jira',
+            'NAME': os.environ.get('JIRA_URL'),
+            'USER': os.environ.get('JIRA_USER'),
+            'PASSWORD': os.environ.get('JIRA_PASSWORD'),
+            'SECURITY': '',
+        },
+
 }
 
-# JIRA
-
-JIRA_CONFIG = { }
-
+DATABASE_ROUTERS = ['django_atlassian.router.Router']
 
 # Password validation
 # https://docs.djangoproject.com/en/2.1/ref/settings/#auth-password-validators
@@ -214,6 +220,15 @@ MEDIA_URL = '/media/'
 
 DEFAULT_FILE_STORAGE = 'database_files.storage.DatabaseStorage'
 AUTH_USER_MODEL = 'panopticum.User'
+
+# JIRA settings.
+JIRA_CONFIG = {
+    # 'URL': 'https://example.com',
+    # 'USER': 'some_user',
+    # 'PASSWORD': ''
+}
+
+
 
 # This will only allow admins to log in as other users, as long as
 # those users are not admins themselves:

--- a/panopticum_django/urls.py
+++ b/panopticum_django/urls.py
@@ -40,6 +40,7 @@ router.register(r'component_type', views.ComponentTypeViewSet)
 router.register(r'component_data_privacy_class', views.ComponentDataPrivacyClassViewSet)
 router.register(r'user', views.UserDetail)
 router.register(r'token', views.Token)
+router.register(r'issue', views.JiraIssueView)
 
 
 urlpatterns = [
@@ -49,8 +50,6 @@ urlpatterns = [
     url('^dashboard/team/', views.dashboard_team, name='team'),
     url('^dashboard/links.html', views.dashboard_components, name='Links'),
     path('api/login/', rest_framework.authtoken.views.obtain_auth_token),
-    re_path(r'^api/jira/([A-Z]*-\d+)', views.JiraIssueView.as_view(), name='jira'),
-    url(r'^api/jira_url/', views.JiraUrlView.as_view(), name='jira_url'),
     path('api/login/', views.LoginAPIView.as_view()),
     path('accounts/', include('django.contrib.auth.urls')),
     url('^api/', include(router.urls)),

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ pillow
 scalpl
 iso3166
 django-database-files-3000
+git+https://github.com/den-gts/django-atlassian.git


### PR DESCRIPTION
If owner or signee notes contain substrings like ```https://myjira.com``` (tuned at settings.py) or ```https://some.com``` that substring will replaced by JIRA ticket id with fixversion and link icon. 

JIRA url retrieved from ```settings.DATABASES.['jira']['NAME']```.

That PR add one more dependency ```django-atlassian```. I fork that and fix many issues. But that dependency allow use JIRA as database and use django ORM